### PR TITLE
lowercase addresses only

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,2 +1,2 @@
 export const tilesUrl = (address: string) =>
-  'https://api.tiles.art/tile/' + address
+  'https://api.tiles.art/tile/' + address.toLowerCase()


### PR DESCRIPTION
Fixes nit that bugs me ;) Tile generator only works with lowercase strings, so force lowercase. Perhaps fixing this at the API level would be better instead.

How to replicate the issue:
- Select and copy your connected address from the top right of the tiles.art page
- Paste into the form field for tile generation
- Even if this address includes capital letters, it will render 
- Now change any character in the address, and it won't render
- Change all capital letters to lowercase, it renders again
